### PR TITLE
Non-blocking fanout

### DIFF
--- a/heaviside/activities.py
+++ b/heaviside/activities.py
@@ -264,14 +264,14 @@ def fanout(session, sub_sfn, sub_args, max_concurrent=50, rampup_delay=15, rampu
     }
 
     while True:
-        args = fanout_async(args, session)
+        args = fanout_nonblocking(args, session)
 
         if args['finished']:
             return args['results']
 
         time.sleep(poll_delay)
 
-def fanout_async(args, session=None):
+def fanout_nonblocking(args, session=None):
     """
     args:
         {

--- a/heaviside/activities.py
+++ b/heaviside/activities.py
@@ -167,15 +167,18 @@ def fanout(session, sub_sfn, sub_args, max_concurrent=50, rampup_delay=15, rampu
                                that can be launched. Once this limit is hit
                                fanout waits until some current executions have
                                finished before launching more sub_sfn.
-        rampup_delay (int) : Initial delay between launches of sub_sfn. Allows
+        rampup_delay (int) : Seconds
+                             Initial delay between launches of sub_sfn. Allows
                              for AWS resources to detect and scale to the large
                              volume of requests that can be generated.
         rampup_backoff (float) : Multiplier for rampup_delay that reduces the
                                  delay until there is no delay left between
                                  launches of sub_sfn.
-        poll_delay (int) : Delay between launching (multiple) sub_sfn and polling
+        poll_delay (int) : Seconds
+                           Delay between launching (multiple) sub_sfn and polling
                            for their status.
-        status_delay (int) : Delay between polling the status of each concurrently
+        status_delay (int) : Seconds
+                             Delay between polling the status of each concurrently
                              executing sub_sfn. Used to limit AWS API request
                              speed of fanout and not run into throttling problems.
 
@@ -217,6 +220,7 @@ def fanout_nonblocking(args, session=None):
 
     Args:
         args: {
+            # See fanout for full details of arguments
             sub_sfn (ARN)
             sub_args (list)
             max_concurrent (int)

--- a/heaviside/tests/test_activities.py
+++ b/heaviside/tests/test_activities.py
@@ -80,6 +80,7 @@ class TestFanout(unittest.TestCase):
             mock.call.start_execution(stateMachineArn = 'XXX',
                                       name = 'ZZZ',
                                       input = '0'),
+            mock.call.list_state_machines(),
             mock.call.describe_execution(executionArn = 'YYY')
         ]
 
@@ -116,6 +117,7 @@ class TestFanout(unittest.TestCase):
             mock.call.start_execution(stateMachineArn = 'XXX',
                                       name = 'ZZZ',
                                       input = '0'),
+            mock.call.list_state_machines(),
             mock.call.describe_execution(executionArn = 'YYY')
         ]
 
@@ -153,10 +155,12 @@ class TestFanout(unittest.TestCase):
             mock.call.start_execution(stateMachineArn = 'XXX',
                                       name = 'ZZZ',
                                       input = '0'),
+            mock.call.list_state_machines(),
             mock.call.describe_execution(executionArn = 'YYY'),
             mock.call.start_execution(stateMachineArn = 'XXX',
                                       name = 'ZZZ',
                                       input = '1'),
+            mock.call.list_state_machines(),
             mock.call.describe_execution(executionArn = 'YYY'),
         ]
 
@@ -207,6 +211,7 @@ class TestFanout(unittest.TestCase):
             mock.call.start_execution(stateMachineArn = 'XXX',
                                       name = 'ZZZ',
                                       input = '1'),
+            mock.call.list_state_machines(),
             mock.call.describe_execution(executionArn = 'YYY'),
             mock.call.get_execution_history(executionArn = 'YYY',
                                             reverseOrder = True),


### PR DESCRIPTION
Moved the core logic of fanout into a fanout_nonblocking function and implemented fanout using the new function. The non-blocking version allows fanout to be called by a Lambda that is part of a StepFunction loop with the poll_delay externalized, saving cost by not having the Lambda sleep.

I reversed the order of the fanout loop (from launch, sleep, check status to check status, launch) so that the sleep could be externalized and that status was not checked immediately after launching.

Example heaviside loop
```py
while '$.finished' == False:
    Lambda('fanout') # just calls heaviside.activities.fanout_nonblocking
    Wait(seconds=10)
transform:
    output: '$.results'
```