### PR TITLE
Goto support

### DIFF
--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -45,7 +45,7 @@ libraries page.
     - [Switch](#Switch)
     - [While Loop](#While-Loop)
     - [Parallel](#Parallel)
-    - [Goto State](#Goto-State)
+    - [Goto](#Goto)
 
 ## Why
 When Amazon released AWS Step Functions they provided a [language definition]

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -358,12 +358,12 @@ Modifiers:
 The `error` block contains the same `retry` and `catch` modifiers as the task state.
 
 #### Goto
-The `goto` control statement allows jumping to another state instead of continuing
-to the next state. This can be used to create common error handling routines (among
-other uses.
+The `goto` control statement allows jumping to another state. This can be used
+to create common error handling routines (among other uses).
 
 The state can only target states within the current branch of execution.  This
-means either the main body of the Step Function or a branch of a Parallel state.
+means either the main body of the Step Function or within a branch of a Parallel
+state.
 
     goto "State Name"
 

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -37,7 +37,6 @@ libraries page.
     - [Success State](#Success-State)
     - [Fail State](#Fail-State)
     - [Pass State](#Pass-State)
-    - [Goto State](#Goto-State)
     - [Task State](#Task-State)
     - [Wait State](#Wait-State)
   - [Flow Control States](#Flow-Control-States)
@@ -46,6 +45,7 @@ libraries page.
     - [Switch](#Switch)
     - [While Loop](#While-Loop)
     - [Parallel](#Parallel)
+    - [Goto State](#Goto-State)
 
 ## Why
 When Amazon released AWS Step Functions they provided a [language definition]
@@ -171,15 +171,6 @@ Modifiers:
 * `result`: JsonPath of where to place the results of the state, relative to the
             raw input (before the `input` modifier was applied) (Default: `"$"`)
 * `data`: A block of Json data that will be used as the result of the state
-
-#### Goto State
-A state that does nothing `Goto()` can be used to transfer control to the named
-state. This is can be to create common error handling routines (among other
-uses).
-
-Note: The Goto state doesn't allow any modifiers, unlike the rest of the states.
-
-    Goto("State Name")
 
 #### Task State
 There are two types of task states, `Lambda()` and `Activity()`. The difference
@@ -365,6 +356,16 @@ Modifiers:
             next state (Default: `"$"`)
 
 The `error` block contains the same `retry` and `catch` modifiers as the task state.
+
+#### Goto
+The `goto` control statement allows jumping to another state instead of continuing
+to the next state. This can be used to create common error handling routines (among
+other uses.
+
+The state can only target states within the current branch of execution.  This
+means either the main body of the Step Function or a branch of a Parallel state.
+
+    goto "State Name"
 
 [stepfunctions library]: https://github.com/jhuapl-boss/heaviside
 [language definition]: https://states-language.net/spec.html

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -37,6 +37,7 @@ libraries page.
     - [Success State](#Success-State)
     - [Fail State](#Fail-State)
     - [Pass State](#Pass-State)
+    - [Goto State](#Goto-State)
     - [Task State](#Task-State)
     - [Wait State](#Wait-State)
   - [Flow Control States](#Flow-Control-States)
@@ -170,6 +171,27 @@ Modifiers:
 * `result`: JsonPath of where to place the results of the state, relative to the
             raw input (before the `input` modifier was applied) (Default: `"$"`)
 * `data`: A block of Json data that will be used as the result of the state
+
+#### Goto State
+A state that does nothing `Goto()` can be used to transfer control to the named
+state. This is can be to create common error handling routines (among other
+uses).
+
+Note: The Goto state doesn't allow any modifiers, unlike the rest of the states.
+
+    Goto("State Name")
+
+    # Example
+    Lambda("Function")
+        catch []: '$.error'
+            Goto("error")
+
+    Success()
+
+    Lambda("ErrorFunction")
+        """error"""
+
+    Fail("error", "cause")
 
 #### Task State
 There are two types of task states, `Lambda()` and `Activity()`. The difference

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -181,18 +181,6 @@ Note: The Goto state doesn't allow any modifiers, unlike the rest of the states.
 
     Goto("State Name")
 
-    # Example
-    Lambda("Function")
-        catch []: '$.error'
-            Goto("error")
-
-    Success()
-
-    Lambda("ErrorFunction")
-        """error"""
-
-    Fail("error", "cause")
-
 #### Task State
 There are two types of task states, `Lambda()` and `Activity()`. The difference
 is where the code that will be executed is living. For `Lambda()` the code is a

--- a/heaviside/ast.py
+++ b/heaviside/ast.py
@@ -555,7 +555,7 @@ def verify_goto_targets(branch):
         CompileError : If a Goto state targets an invalid state
     """
     if not hasattr(branch, 'states'):
-        branch.raise_error("Trying to check names for non-branch state")
+        branch.raise_error("Trying to check goto targets for non-branch state")
 
     to_process = [branch.states]
 
@@ -573,4 +573,4 @@ def verify_goto_targets(branch):
         for state in states:
             if isinstance(state.next, ASTModNext):
                 if state.next.value not in names:
-                    state.raise_error("Goto target '{}' doesn't exist".format(state.next.value))
+                    state.next.raise_error("Goto target '{}' doesn't exist".format(state.next.value))

--- a/heaviside/parser.py
+++ b/heaviside/parser.py
@@ -242,6 +242,9 @@ def parse(seq, translate=lambda x, y: y):
 
 
     # Simple States
+    # DP Note: The 'next' modifier is not allowed in general usage, must use the 'Goto'
+    #          state to create that modifier. If 'next' should be allowed from any state
+    #          just add it to 'state_modifier' and 'transform_modifier'
     state_modifier = ((n('timeout') + op_(':') + integer_pos >> make(ASTModTimeout)) |
                       (n('heartbeat') + op_(':') + integer_pos >> make(ASTModHeartbeat)) |
                       (n('input') + op_(':') + string >> make(ASTModInput)) |
@@ -253,13 +256,14 @@ def parse(seq, translate=lambda x, y: y):
     state_modifiers = state_modifier + many(state_modifier) >> make(ASTModifiers)
     state_block = maybe(block_s + maybe(string) + maybe(state_modifiers) + block_e)
 
+    goto = n('Goto') + op_('(') + string + op_(')') >> make(ASTStateGoto)
     pass_ = n('Pass') + op_('(') + op_(')') + state_block >> make(ASTStatePass)
     success = n('Success') + op_('(') + op_(')') + state_block >> make(ASTStateSuccess)
     fail = n('Fail') + op_('(') + string + op_(',') + string + op_(')') + state_block >> make(ASTStateFail)
     task = (n('Lambda') | n('Activity')) + op_('(') + string + op_(')') + state_block >> make(ASTStateTask)
     wait_types = n('seconds') | n('seconds_path') | n('timestamp') | n('timestamp_path')
     wait = n('Wait') + op_('(') + wait_types + op_('=') + (integer_pos|timestamp_or_string) + op_(')') + state_block >> make(ASTStateWait)
-    simple_state = pass_ | success | fail | task | wait
+    simple_state = goto | pass_ | success | fail | task | wait
 
     # Flow Control States
     transform_modifier = ((n('input') + op_(':') + string >> make(ASTModInput)) |

--- a/heaviside/parser.py
+++ b/heaviside/parser.py
@@ -302,6 +302,7 @@ def parse(seq, translate=lambda x, y: y):
         link_branch(tree)
         check_names(tree)
         resolve_arns(tree, translate)
+        verify_goto_targets(tree)
         function = StepFunction(tree)
         #import code
         #code.interact(local=locals())

--- a/heaviside/sfn.py
+++ b/heaviside/sfn.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 
 import iso8601 # parser for timestamp format
 
-from .ast import ASTStateChoice, ASTCompOp, ASTCompNot, ASTCompAndOr, ASTValue
+from .ast import ASTStateChoice, ASTCompOp, ASTCompNot, ASTCompAndOr, ASTValue, ASTModNext
 
 class Timestamp(object):
     """Wrapper around a timestamp string.
@@ -161,7 +161,10 @@ class State(dict):
                 self['Branches'].append(Branch(branch))
 
         if ast.next is not None:
-            self['Next'] = ast.next
+            if isinstance(ast.next, ASTModNext):
+                self['Next'] = ast.next.value
+            else:
+                self['Next'] = ast.next
 
         if ast.end:
             self['End'] = ast.end

--- a/heaviside/tests/sfn/error_invalid_goto_target.sfn
+++ b/heaviside/tests/sfn/error_invalid_goto_target.sfn
@@ -1,0 +1,7 @@
+
+parallel:
+    Pass()
+        "Target"
+
+parallel:
+    Goto("Target")

--- a/heaviside/tests/sfn/error_invalid_goto_target.sfn
+++ b/heaviside/tests/sfn/error_invalid_goto_target.sfn
@@ -4,4 +4,4 @@ parallel:
         "Target"
 
 parallel:
-    Goto("Target")
+    goto "Target"

--- a/heaviside/tests/test_compile.py
+++ b/heaviside/tests/test_compile.py
@@ -99,6 +99,9 @@ class TestCompile(unittest.TestCase):
     def test_duplicate_state_name(self):
         self.execute('error_duplicate_state_name.sfn', "Duplicate state name 'Test'")
 
+    def test_invalid_goto_target(self):
+        self.execute('error_invalid_goto_target.sfn', "Goto target 'Target' doesn't exist")
+
 class TestTranslate(unittest.TestCase):
     def test_lambda(self):
         expected = 'arn:aws:lambda:region:account:function:Test'

--- a/heaviside/tests/test_utils.py
+++ b/heaviside/tests/test_utils.py
@@ -65,7 +65,7 @@ class TestRead(unittest.TestCase):
             self.assertEqual(data, fh.read())
 
     def test_unsuported(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             with utils.read(None) as fh:
                 pass
 

--- a/tests/full.hsd
+++ b/tests/full.hsd
@@ -58,7 +58,7 @@ transform:
     input: '$.foo'
     output: '$.foo'
 
-if '$.foo' == 1 or ('$.foo' >= 10 and '$.foo' < 20):
+if '$.foo' == 1 or ('$.foo' >= 10 and (not '$.foo' < 20)):
     """If-Elif-Else"""
     Pass()
 elif '$.foo' <= 1:
@@ -99,6 +99,11 @@ elif '$.foo' > '1111-11-11T11:11:11Z':
     Pass()
 elif '$.foo' != '1111-11-11T11:11:11Z':
     Pass()
+else:
+    Pass()
+transform:
+    input: '$.foo'
+    output: '$.foo'
 
 switch '$.a':
     """Switch"""
@@ -108,9 +113,12 @@ switch '$.a':
         Pass()
     case '1111-11-11T11:11:11Z':
         Pass()
+    case false:
+        Pass()
     default:
         Pass()
 transform:
+    input: '$.foo'
     output: '$.foo'
 
 parallel:
@@ -128,7 +136,9 @@ parallel:
 
 transform:
     input: '$.foo'
+    result: '$.foo'
+    output: '$.foo'
 error:
     retry [] 1 0 1.0
     catch []:
-        Pass()
+        Goto('Switch')

--- a/tests/full.hsd
+++ b/tests/full.hsd
@@ -141,4 +141,4 @@ transform:
 error:
     retry [] 1 0 1.0
     catch []:
-        Goto('Switch')
+        goto 'Switch'

--- a/tests/full.sfn
+++ b/tests/full.sfn
@@ -110,7 +110,9 @@
          "Next": "While"
       }, 
       "If-Elif-Else": {
-         "Default": "Switch", 
+         "InputPath": "$.foo", 
+         "OutputPath": "$.foo", 
+         "Default": "Line103", 
          "Type": "Choice", 
          "Choices": [
             {
@@ -126,8 +128,10 @@
                            "NumericGreaterThanEquals": 10
                         }, 
                         {
-                           "Variable": "$.foo", 
-                           "NumericLessThan": 20
+                           "Not": {
+                              "Variable": "$.foo", 
+                              "NumericLessThan": 20
+                           }
                         }
                      ]
                   }
@@ -319,41 +323,55 @@
          "Type": "Pass", 
          "Next": "Switch"
       }, 
+      "Line103": {
+         "Type": "Pass", 
+         "Next": "Switch"
+      }, 
       "Switch": {
+         "InputPath": "$.foo", 
          "OutputPath": "$.foo", 
-         "Default": "Line112", 
+         "Default": "Line119", 
          "Type": "Choice", 
          "Choices": [
             {
                "Variable": "$.a", 
-               "Next": "Line106", 
+               "Next": "Line111", 
                "NumericEquals": 1
             }, 
             {
                "Variable": "$.a", 
                "StringEquals": "foo", 
-               "Next": "Line108"
+               "Next": "Line113"
             }, 
             {
                "Variable": "$.a", 
                "TimestampEquals": "1111-11-11T11:11:11Z", 
-               "Next": "Line110"
+               "Next": "Line115"
+            }, 
+            {
+               "Variable": "$.a", 
+               "BooleanEquals": false, 
+               "Next": "Line117"
             }
          ]
       }, 
-      "Line106": {
+      "Line111": {
          "Type": "Pass", 
          "Next": "Parallel"
       }, 
-      "Line108": {
+      "Line113": {
          "Type": "Pass", 
          "Next": "Parallel"
       }, 
-      "Line110": {
+      "Line115": {
          "Type": "Pass", 
          "Next": "Parallel"
       }, 
-      "Line112": {
+      "Line117": {
+         "Type": "Pass", 
+         "Next": "Parallel"
+      }, 
+      "Line119": {
          "Type": "Pass", 
          "Next": "Parallel"
       }, 
@@ -392,21 +410,23 @@
                "StartAt": "Fail"
             }
          ], 
+         "ResultPath": "$.foo", 
+         "OutputPath": "$.foo", 
          "Catch": [
             {
                "ErrorEquals": [
                   "States.ALL"
                ], 
-               "Next": "Line134"
+               "Next": "Line144"
             }
          ], 
          "InputPath": "$.foo", 
          "End": true, 
          "Type": "Parallel"
       }, 
-      "Line134": {
-         "End": true, 
-         "Type": "Pass"
+      "Line144": {
+         "Type": "Pass", 
+         "Next": "Switch"
       }
    }, 
    "Comment": "State machine comment", 


### PR DESCRIPTION
Adding support for a new `Goto("state name")` state that will allow jumping to any state within the branch of execution. Added a check to verify that the named state is valid.

Added for mainly for the use case of common error handling
```
Lambda("function1")
    catch []: '$.error'
        Goto("handler")
        
Lambda("function2")
    catch []: '$.error'
        Goto("handler")
        
Lambda("function3")
    catch []: '$.error'
        Goto("handler")
        
Success()

Lambda("handler")
    """handler
    common error handler function
    """
    
Fail('error', 'cause')
```
----
Edit: Changed the syntax from `Goto('state name')` to `goto 'state name'`