### PR TITLE
Added support for parameters in Pass states.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Heaviside Changelog
 
-## 2.1.0 (pre-release)
+## 2.1.0
  * Fixed bug in packaging `aws_service.json` definition file
  * Fix bug in `heaviside.ast.StateVisitor` implementation
  * Added support for updating existing Step Functions
+ * Added support for specifying parameters for Pass states
 
 ## 2.0
  * New features

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -164,12 +164,17 @@ around or inject new data into the results.
         input: JsonPath
         result: JsonPath
         output: JsonPath
+        parameters:
+            Key1: {"JSON": "Text"}
+            Key2: "string-value"
         data:
             Json
 
 Modifiers:
 * `result`: JsonPath of where to place the results of the state, relative to the
             raw input (before the `input` modifier was applied) (Default: `"$"`)
+* `parameters`: Keyword arguments to be passed in the API call. The value is a
+                JSON text.  These wil be added to the incoming input.
 * `data`: A block of Json data that will be used as the result of the state
 
 #### Task State

--- a/docs/StepFunctionDSL.md
+++ b/docs/StepFunctionDSL.md
@@ -173,8 +173,12 @@ around or inject new data into the results.
 Modifiers:
 * `result`: JsonPath of where to place the results of the state, relative to the
             raw input (before the `input` modifier was applied) (Default: `"$"`)
-* `parameters`: Keyword arguments to be passed in the API call. The value is a
-                JSON text.  These wil be added to the incoming input.
+* `parameters`: Keyword arguments to be passed in the API call. The value is
+                JSON text.  The parameters will override the the incoming
+                input, but JsonPaths may be used to select from existing
+                inputs.
+                NOTE: If the value contains a JsonPath the key must end wit `.$`
+                AWS documentation: https://docs.aws.amazon.com/step-functions/latest/dg/input-output-inputpath-params.html
 * `data`: A block of Json data that will be used as the result of the state
 
 #### Task State

--- a/heaviside/ast.py
+++ b/heaviside/ast.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -273,7 +273,7 @@ class ASTState(ASTNode):
 
 class ASTStatePass(ASTState):
     state_type = 'Pass'
-    valid_modifiers = [ASTModInput, ASTModResult, ASTModOutput, ASTModData]
+    valid_modifiers = [ASTModInput, ASTModResult, ASTModOutput, ASTModData, ASTModParameters]
 
 class ASTStateGoto(ASTStatePass):
     """Custom version of Pass that exposes / sets the 'next' modifier"""

--- a/heaviside/sfn.py
+++ b/heaviside/sfn.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -137,6 +137,10 @@ class State(dict):
         if ast.state_type == 'Fail':
             self['Error'] = ast.error.value
             self['Cause'] = ast.cause.value
+
+        if ast.state_type == 'Pass':
+            if ast.parameters is not None:
+                self['Parameters'] = Parameters(ast.parameters)
 
         if ast.state_type == 'Task':
             self['Resource'] = ast.arn

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Allow using `Parameters` in Pass states so new key-values to pass to the next state without the new value being an object. This can't be done with the existing `data` modifier which compiles to `Result`.

See https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-pass-state.html

FYI, CircleCI needs to be updated to the new format for tests to run and pass. Tests passed locally.
