### PR TITLE
Catch duplicate state names within iterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Heaviside Changelog
 
+## 2.2.2
+ * Catch duplicate state names within a map's iterator
+
 ## 2.2.1
  * Fixed issues with Map state with while blocks and resolving ARNs
 

--- a/heaviside/ast.py
+++ b/heaviside/ast.py
@@ -667,6 +667,9 @@ def check_names(branch):
             if isinstance(state, ASTStateParallel):
                 for branch in state.branches:
                     to_process.append(branch.states)
+            elif isinstance(state, ASTStateMap):
+                # Check the map state's internal state machine
+                to_process.append(state.iterator.states)
 
 def resolve_arns(branch, region = '', account_id = ''):
     """AST Transform that sets the `arn` attribute for ASTStateTasks

--- a/heaviside/tests/sfn/error_map_iterator_duplicate_state_name.sfn
+++ b/heaviside/tests/sfn/error_map_iterator_duplicate_state_name.sfn
@@ -1,0 +1,29 @@
+version: "1.0"
+timeout: 60
+Pass()
+    """CreateSomeInputs"""
+    result: '$'
+    data:
+        {
+            "the_array": [1, 2, 3, 4, 5],
+            "foo": "bar"
+        }
+map:
+    """TransformInputsWithMap"""
+    iterator:
+        Lambda('myfunc')
+            """DuplicateName"""
+        Success()
+            """DuplicateName"""
+    parameters:
+        foo.$: "$.foo"
+        element.$: "$$.Map.Item.Value"
+    items_path: "$.the_array"
+    result: "$.transformed"
+    output: "$.transformed"
+    max_concurrency: 4
+    retry [] 1 0 1.0 
+    catch []:
+        Pass()
+            """SomeErrorHandler"""
+

--- a/heaviside/tests/test_compile.py
+++ b/heaviside/tests/test_compile.py
@@ -152,3 +152,6 @@ class TestCompile(unittest.TestCase):
 
     def test_map_without_iterator(self):
         self.execute('error_map_has_no_iterator.sfn', 'Map state must have an iterator')
+
+    def test_map_iterator_has_duplicate_state_name(self):
+        self.execute('error_map_iterator_duplicate_state_name.sfn', "Duplicate state name 'DuplicateName'")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 # python setup.py bdist_wheel
 # twine upload --skip-existing dist/*
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 
 import os
 


### PR DESCRIPTION
The states within a map's iterator were not checked for duplicate names. This bit me today when I forgot to update the name of one of the iterator's states. 😢 