### PR TITLE
specify pos and max values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,6 @@ commands:
       - run: python3 -m unittest discover
 
 jobs:
-  test_py3_7:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - install:
-          pyversion: python3.7
-      - test_heaviside
-
   test_py3_8:
     docker:
       - image: circleci/python:3.8
@@ -47,7 +39,6 @@ jobs:
 workflows:
   test:
     jobs:
-      - test_py3_7
       - test_py3_8
       - test_py3_9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.3
  * Update funcparserlib version to ensure compatibility with Python 3.8 and above.
+ * Dropped support for Python 3.7
 
 ## 2.2.2
  * Catch duplicate state names within a map's iterator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Heaviside Changelog
 
+## 2.2.3
+ * Update funcparserlib version to ensure compatibility with Python 3.8 and above.
+
 ## 2.2.2
  * Catch duplicate state names within a map's iterator
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ execution has finished and will print the output of the StepFunction.
 The Heaviside package installs the Python library `heaviside`. The public
 API is documented in the [Library API](docs/LibraryAPI.md) file.
 
-## Compatability
+## Compatibility
 
-Currently Heaviside has only been tested with Python 2.7 and 3.5.
+Currently, Heaviside has only been tested with Python 3.8.
 
 ## Related Projects
 

--- a/heaviside/parser.py
+++ b/heaviside/parser.py
@@ -321,7 +321,7 @@ def parse(seq, region = '', account_id = '', visitors=[]):
 
     try:
         # DP NOTE: calling run() directly to have better control of error handling
-        (tree, _) = machine.run(seq, State())
+        (tree, _) = machine.run(seq, State(pos=0, max=0))
         link_branch(tree)
         check_names(tree)
         resolve_arns(tree, region, account_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 # Check 
 hvac>=0.11.2, <1.0.0
-# funcparserlib changed after 0.3.6 and now requires two positional arguments: 'pos' and 'max' when using run.
-# To use funcparserlib 0.3.6 requires setuptools<58.0
-# see https://bobbyhadz.com/blog/python-error-in-package-setup-command-use-2to3-is-invalid
-setuptools<58.0
-funcparserlib==0.3.6
+setuptools==69
+funcparserlib==1.0.1
 iso8601
 boto3>=1.4.3
 importlib_resources

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 # python setup.py bdist_wheel
 # twine upload --skip-existing dist/*
 
-__version__ = '2.2.2'
+__version__ = '2.2.3'
 
 import os
 


### PR DESCRIPTION
This change just specifies values for `pos` and `max` in funcparserlib `State()` class initialization. These variables are used only for error tracking

https://github.com/vlasovskikh/funcparserlib/blob/master/funcparserlib/parser.py#L513


The original code was compatible only with `funcparserlib==0.3.6` or lower. This change allows the activities stack to finish building with `funcparserlib>=1.0.0`.

```python
Traceback (most recent call last):
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/bin/./cloudformation.py", line 301, in <module>
    call_configs(bosslet_config, configs, func)
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/bin/./cloudformation.py", line 201, in call_configs
    module.__dict__[func_name](bosslet_config)
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/cloud_formation/configs/activities.py", line 233, in post_init
    sfn.create(bosslet_config, name, path, role)
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/lib/stepfunctions.py", line 43, in create
    machine.create(filepath, role)
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/lib/heaviside.git/heaviside/__init__.py", line 142, in create
    definition = self.build(source)
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/lib/heaviside.git/heaviside/__init__.py", line 108, in build
    return compile(source,
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/lib/heaviside.git/heaviside/__init__.py", line 51, in compile
    machine = parse(tokens,
  File "/Users/xenesd1/Projects/BossDB/code/boss-manage/lib/heaviside.git/heaviside/parser.py", line 324, in parse
    (tree, _) = machine.run(seq, State())
TypeError: __init__() missing 2 required positional arguments: 'pos' and 'max'
```

I couldn't downgrade because funcparserlib==0.3.6 is no longer compatible with python 3.8 and above due to a PEP change.
