### PR TITLE
Upgrade to python3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Heaviside Changelog
+## 2.2.4
+ * Added support for Python 3.11
 
 ## 2.2.3
  * Update funcparserlib version to ensure compatibility with Python 3.8 and above.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ API is documented in the [Library API](docs/LibraryAPI.md) file.
 
 ## Compatibility
 
-Currently, Heaviside has only been tested with Python 3.8.
+Currently, Heaviside has only been tested with Python 3.8 and 3.11
 
 ## Related Projects
 

--- a/heaviside/utils.py
+++ b/heaviside/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2024 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,17 @@
 import json
 import sys
 from io import IOBase, StringIO
-from collections import Mapping
 from contextlib import contextmanager
 
 from boto3.session import Session
+
+# With Python3.11 Mapping is imported from collections.abc
+# Try to import with the new method and if it fails fall back to old way for compatibility
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 
 try:
     from urllib.request import urlopen

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     keywords=[
-        'boss',
+        'bossdb',
         'microns',
         'aws',
         'stepfunctions',


### PR DESCRIPTION
Updates needed for Python 3.11 to run. 

Should we remove support for Python 2?

